### PR TITLE
Workflow-release

### DIFF
--- a/.github/workflows/release-zip.yml
+++ b/.github/workflows/release-zip.yml
@@ -1,0 +1,52 @@
+name: Release Extension ZIP
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-zip:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get release tag
+        id: get_tag
+        run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Read manifest version
+        id: manifest_version
+        run: |
+          MANIFEST_VERSION=$(jq -r .version manifest.json)
+          echo "MANIFEST_VERSION=$MANIFEST_VERSION" >> $GITHUB_ENV
+
+      - name: Check version match
+        run: |
+          if [ "$RELEASE_TAG" != "$MANIFEST_VERSION" ]; then
+            echo "Erreur : le tag de release ($RELEASE_TAG) ne correspond pas à la version du manifest.json ($MANIFEST_VERSION)."
+            exit 1
+          fi
+
+      - name: Create extension package folder
+        run: |
+          mkdir ext-dist
+          cp manifest.json ext-dist/
+          cp background.js ext-dist/
+          cp utils.js ext-dist/
+          cp -r icons ext-dist/
+
+      - name: Create ZIP archive
+        run: |
+          cd ext-dist
+          zip -r ../ChromeExt-CW-TMDB-v$RELEASE_TAG.zip .
+
+      - name: Upload ZIP to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./ChromeExt-CW-TMDB-v$RELEASE_TAG.zip
+          asset_name: ChromeExt-CW-TMDB-v$RELEASE_TAG.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release-zip.yml
+++ b/.github/workflows/release-zip.yml
@@ -1,6 +1,7 @@
 name: Release Extension ZIP
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/release-zip.yml
+++ b/.github/workflows/release-zip.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Get release tag
         id: get_tag
-        run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" | sed 's/^v//' >> $GITHUB_ENV
 
       - name: Read manifest version
         id: manifest_version
@@ -43,11 +43,8 @@ jobs:
           zip -r ../ChromeExt-CW-TMDB-v$RELEASE_TAG.zip .
 
       - name: Upload ZIP to release
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ChromeExt-CW-TMDB-v$RELEASE_TAG.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./ChromeExt-CW-TMDB-v$RELEASE_TAG.zip
-          asset_name: ChromeExt-CW-TMDB-v$RELEASE_TAG.zip
-          asset_content_type: application/zip

--- a/.github/workflows/release-zip.yml
+++ b/.github/workflows/release-zip.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Get release tag
         id: get_tag
-        run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" | sed 's/^v//' >> $GITHUB_ENV
+        run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
 
       - name: Read manifest version
         id: manifest_version

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ ext/
 # Fichiers système
 Thumbs.db
 # Fichiers de configuration IDE
-.github/
+*-instructions.md
+guidance/

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,6 @@ JEST.md
 ext/
 # Fichiers système
 Thumbs.db
-# Fichiers de configuration IDE
+# Ignorer la documentation et les fichiers d'orientation afin d'éviter les transferts accidentels d'instructions internes.
 *-instructions.md
 guidance/


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the creation and upload of a ZIP package for the Chrome extension upon release. The workflow ensures the release tag matches the version in the `manifest.json` file and packages the necessary files into a ZIP archive.

### New GitHub Actions workflow for extension packaging:

* [`.github/workflows/release-zip.yml`](diffhunk://#diff-81aecafa14da8f3dd2db15a9bab009fe05645c76761be3c3710bec911e5b198dR1-R50): Added a workflow named "Release Extension ZIP" that triggers on `workflow_dispatch` and `release` events. It checks out the code, validates the release tag against the `manifest.json` version, creates a folder for the extension package, copies required files (`manifest.json`, `background.js`, `utils.js`, and `icons`), generates a ZIP archive, and uploads it to the release using `softprops/action-gh-release`.