### PR TITLE
fix: Corriger la syntaxe des variables d'environnement dans le workflow de création de ZIP

### DIFF
--- a/.github/workflows/release-zip.yml
+++ b/.github/workflows/release-zip.yml
@@ -40,11 +40,11 @@ jobs:
       - name: Create ZIP archive
         run: |
           cd ext-dist
-          zip -r ../ChromeExt-CW-TMDB-v$RELEASE_TAG.zip .
+          zip -r ../ChromeExt-CW-TMDB-v${{ env.RELEASE_TAG }}.zip .
 
       - name: Upload ZIP to release
         uses: softprops/action-gh-release@v1
         with:
-          files: ChromeExt-CW-TMDB-v$RELEASE_TAG.zip
+          files: ChromeExt-CW-TMDB-v${{ env.RELEASE_TAG }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/release-zip.yml` file to improve the handling of environment variables in the release workflow.

Workflow improvements:

* Updated the `Create ZIP archive` step to use `${{ env.RELEASE_TAG }}` instead of `$RELEASE_TAG` for better compatibility with GitHub Actions environment variables. [[1]](diffhunk://#diff-81aecafa14da8f3dd2db15a9bab009fe05645c76761be3c3710bec911e5b198dL43-R48)
* Updated the `Upload ZIP to release` step to use `${{ env.RELEASE_TAG }}` for consistency and alignment with the updated environment variable handling. [[1]](diffhunk://#diff-81aecafa14da8f3dd2db15a9bab009fe05645c76761be3c3710bec911e5b198dL43-R48)