### PR TITLE
chore: Ajouter les permissions pour l'écriture du contenu dans le workflow de création de ZIP

### DIFF
--- a/.github/workflows/release-zip.yml
+++ b/.github/workflows/release-zip.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   build-zip:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the `.github/workflows/release-zip.yml` file to include permissions for writing contents during the release workflow.

Permissions update:

* [`.github/workflows/release-zip.yml`](diffhunk://#diff-81aecafa14da8f3dd2db15a9bab009fe05645c76761be3c3710bec911e5b198dR8-R10): Added `permissions` configuration with `contents: write` to enable write access for contents in the release workflow.