### PR TITLE
fix: Corriger la logique de détection des URLs TMDB et CaptainWatch dans les listeners

### DIFF
--- a/background.js
+++ b/background.js
@@ -58,8 +58,10 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   if (!tab.url) {
     return;
   }
-  const isCaptainWatch = extractTypeAndId(tab.url) !== null;
-  const isTMDB = extractTypeAndIdFromTMDB(tab.url) !== null;
+  const tmdbUrl = generateTMDBUrl(tab.url);
+  const cwUrl = generateCaptainWatchUrl(tab.url);
+  const isTMDB = !!tmdbUrl;
+  const isCaptainWatch = !!cwUrl;
   if (isCaptainWatch || isTMDB) {
     chrome.action.enable(tabId);
     updateIcon(tabId, true, isTMDB);
@@ -74,7 +76,8 @@ chrome.runtime.onInstalled.addListener(() => {
   chrome.tabs.query({}, (tabs) => {
     for (const tab of tabs) {
       if (tab.id) {
-        const isTMDB = tab.url && extractTypeAndIdFromTMDB(tab.url) !== null;
+        const tmdbUrl = tab.url && generateTMDBUrl(tab.url);
+        const isTMDB = !!tmdbUrl;
         updateIcon(tab.id, false, isTMDB);
       }
     }


### PR DESCRIPTION
This pull request refactors URL handling in the `background.js` file to improve readability and maintainability. The changes replace direct type and ID extraction methods with URL generation functions and simplify conditional checks.

### Refactoring of URL handling:

* [`chrome.tabs.onUpdated.addListener`](diffhunk://#diff-bb06783fccd762e4d905ab922491e954a9fbaf708a1acbf53dff92872b0bcd3bL61-R64): Replaced calls to `extractTypeAndId` and `extractTypeAndIdFromTMDB` with `generateCaptainWatchUrl` and `generateTMDBUrl` functions to determine `isCaptainWatch` and `isTMDB` values. This improves clarity by directly working with generated URLs instead of extracted types and IDs.
* [`chrome.runtime.onInstalled.addListener`](diffhunk://#diff-bb06783fccd762e4d905ab922491e954a9fbaf708a1acbf53dff92872b0bcd3bL77-R80): Updated logic to use `generateTMDBUrl` for determining `isTMDB`, simplifying the conditional check for tabs during initialization.