### PR TITLE
build: Mettre à jour le script de release pour utiliser commit-and-tag-version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "scripts": {
     "test": "jest",
     "sync-version": "node sync-version.js",
-    "release": "standard-version --dry-run"
+    "release": "commit-and-tag-version --dry-run"
   },
   "keywords": [],
   "author": "Vhivi",
   "license": "MIT",
   "devDependencies": {
-    "jest": "^30.0.4",
-    "standard-version": "^9.5.0"
+    "commit-and-tag-version": "^12.5.1",
+    "jest": "^30.0.4"
   }
 }


### PR DESCRIPTION
This pull request updates the release process by replacing the `standard-version` package with `commit-and-tag-version` in the `package.json` file.

### Updates to the release process:

* Updated the `release` script to use `commit-and-tag-version` instead of `standard-version` [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L9-R16).
* Replaced the `standard-version` dependency with `commit-and-tag-version` in the `devDependencies` section [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L9-R16).